### PR TITLE
Update specifyInput.R 

### DIFF
--- a/R/specifyInput.R
+++ b/R/specifyInput.R
@@ -52,7 +52,7 @@ specifyInput <- function(data, hhid, hhsize=NULL, pid=NULL, weight=NULL,
       stop("strata must be a character defining the variable holding information on stratas and must be of length 1!\n")
     }
     if(!"factor"%in%class(data[[strata]])){
-      stop(strata,"is not a factor variable as needed for a strata variable.")
+      stop(strata," is not a factor variable as needed for a strata variable.")
     }
   }
 


### PR DESCRIPTION
Hello, I have a little cosmetic proposal to offer.
The error message is missing a space between name of variable and the rest of the text.
I had the error message - kod_KRAJis not a factor variable as needed for a strata variable.
With the space it would be prettier - kod_KRAJ is not a factor variable as needed for a strata variable.