### PR TITLE
Update simStructure

### DIFF
--- a/R/simStructure.R
+++ b/R/simStructure.R
@@ -21,6 +21,8 @@
 #' @param seed optional; an integer value to be used as the seed of the random
 #' number generator, or an integer vector containing the state of the random
 #' number generator to be restored.
+#' @param MaxNWts optional; an integer value for the multinom method  for controlling 
+#' the maximum number of weights.
 #' @return An object of class \code{simPopObj} containing the simulated
 #' population household structure as well as the underlying sample that was
 #' provided as input.

--- a/R/simStructure.R
+++ b/R/simStructure.R
@@ -21,7 +21,7 @@
 #' @param seed optional; an integer value to be used as the seed of the random
 #' number generator, or an integer vector containing the state of the random
 #' number generator to be restored.
-#' @param MaxNWts optional; an integer value for the multinom method  for controlling 
+#' @param MaxNWts optional; an integer value for the multinom method for controlling 
 #' the maximum number of weights.
 #' @return An object of class \code{simPopObj} containing the simulated
 #' population household structure as well as the underlying sample that was

--- a/R/simStructure.R
+++ b/R/simStructure.R
@@ -118,6 +118,19 @@ simStructure <- function(dataS, method=c("direct", "multinom", "distribution"), 
       # boost <- 1/sqrt(fraction)
       # probs[probs < fraction] <- pmin(fraction, boost*probs[probs < fraction])
       hsizePH <- unlist(lapply(ls, function(l) spSample(NH[l], probs[l,])))
+      hsizePH <- unlist(lapply(ls, function(l) {
+                # spSample(NH[l], probs[l,]) was removed and insides was adjusted
+                # length(p) was replaced with as.numeric(names(p))
+        n <-  NH[l]
+        p <- probs[l,]
+        
+        sample(as.numeric(names(p)),
+               size = n, 
+               replace = TRUE,
+               prob = p)
+      }
+                               )
+                        )                         
     } else if ( method == "distribution" ) {
       hsizePH <- unlist(lapply(ls, function(l) spSample(NH[l], households[, l])))
     }
@@ -154,11 +167,7 @@ simStructure <- function(dataS, method=c("direct", "multinom", "distribution"), 
     n <- households[grid[i, 1], grid[i, 2]]
     w <- wH[split[[i]]]
     p <- w / sum(w)  # probability weights
-    if(length(p) == 0) {
-      integer(0)
-    } else {
-      spSample(n, p)
-    }
+    spSample(n, p)
   })
 
   ### generation of the household structure for the population

--- a/R/simStructure.R
+++ b/R/simStructure.R
@@ -117,7 +117,6 @@ simStructure <- function(dataS, method=c("direct", "multinom", "distribution"), 
       # fraction <- nrow(dataH)/nrow(dataPH)
       # boost <- 1/sqrt(fraction)
       # probs[probs < fraction] <- pmin(fraction, boost*probs[probs < fraction])
-      hsizePH <- unlist(lapply(ls, function(l) spSample(NH[l], probs[l,])))
       hsizePH <- unlist(lapply(ls, function(l) {
                 # spSample(NH[l], probs[l,]) was removed and insides was adjusted
                 # length(p) was replaced with as.numeric(names(p))

--- a/R/simStructure.R
+++ b/R/simStructure.R
@@ -43,7 +43,7 @@
 #' class(eusilcP)
 #' eusilcP
 #' 
-simStructure <- function(dataS, method=c("direct", "multinom", "distribution"), basicHHvars, seed=1) {
+simStructure <- function(dataS, method=c("direct", "multinom", "distribution"), basicHHvars, seed=1, MaxNWts = 10000000) {
   if ( !class(dataS) == "dataObj" ) {
     stop("Error. Please provide the input sample in the required format.\n
       It must be an object of class 'dataObj' that can be created using function specifyInput()!\n")
@@ -107,7 +107,7 @@ simStructure <- function(dataS, method=c("direct", "multinom", "distribution"), 
     if ( method == "multinom" ) {
       empty <- which(households == 0)
       # TODO: allow setting some more arguments
-      mod <- suppressWarnings(multinom(hsize~strata, weights=wH, data=dataH, trace=FALSE))
+      mod <- suppressWarnings(multinom(hsize~strata, weights=wH, data=dataH, trace=FALSE, MaxNWts = MaxNWts))
       newdata <- data.frame(strata=ls)
       rownames(newdata) <- ls
       probs <- as.matrix(predict(mod, newdata=newdata, type="probs"))
@@ -152,7 +152,11 @@ simStructure <- function(dataS, method=c("direct", "multinom", "distribution"), 
     n <- households[grid[i, 1], grid[i, 2]]
     w <- wH[split[[i]]]
     p <- w / sum(w)  # probability weights
-    spSample(n, p)
+    if(length(p) == 0) {
+      integer(0)
+    } else {
+      spSample(n, p)
+    }
   })
 
   ### generation of the household structure for the population


### PR DESCRIPTION
Hello,

I was playing with the method of multinom for simulation of household size
and had this error:
Error in nnet.default(X, Y, w, mask = mask, size = 0, skip = TRUE, softmax = TRUE,  : 
  too many (1404) weights

So according to the answer in https://stackoverflow.com/questions/36303404/too-many-weights-in-multinomial-logistic-regression-and-the-code-is-running-for
I added argument MaxNWts which in the nnet package is in general for controlling the maximum number of weights.

Then another error appeared in lapply where we draw from original sample for each stratum
Error in sample.int(length(x), size, replace, prob) : 
incorrect number of probabilities

This was just caused by my data because  
n <- households[grid[i, 1], grid[i, 2]] **(= 0)**
w <- wH[split[[i]]] **(= numeric (empty))**
p <- w / sum(w) **(= numeric (empty))**
And sample function doesn't seem to cooperate with numeric (empty) input so I added a condition that if the p is empty then just add 0 otherwise calculate spSample(n,p)

After that the code run

Do you agree with the changes?

