### PR TITLE
multiom method 

### DIFF
--- a/R/simStructure.R
+++ b/R/simStructure.R
@@ -21,6 +21,8 @@
 #' @param seed optional; an integer value to be used as the seed of the random
 #' number generator, or an integer vector containing the state of the random
 #' number generator to be restored.
+#' @param MaxNWts optional; an integer value for the multinom method  for controlling 
+#' the maximum number of weights.
 #' @return An object of class \code{simPopObj} containing the simulated
 #' population household structure as well as the underlying sample that was
 #' provided as input.

--- a/R/simStructure.R
+++ b/R/simStructure.R
@@ -21,7 +21,7 @@
 #' @param seed optional; an integer value to be used as the seed of the random
 #' number generator, or an integer vector containing the state of the random
 #' number generator to be restored.
-#' @param MaxNWts optional; an integer value for the multinom method  for controlling 
+#' @param MaxNWts optional; an integer value for the multinom method for controlling 
 #' the maximum number of weights.
 #' @return An object of class \code{simPopObj} containing the simulated
 #' population household structure as well as the underlying sample that was

--- a/R/simStructure.R
+++ b/R/simStructure.R
@@ -131,7 +131,6 @@ simStructure <- function(dataS, method=c("direct", "multinom", "distribution"), 
                                )
                         )                         
     } else if ( method == "distribution" ) {
-      hsizePH <- unlist(lapply(ls, function(l) spSample(NH[l], households[, l])))
       hsizePH <- unlist(lapply(ls, function(l) {
                  # spSample(NH[l], households[, l]) was removed and insides was adjusted
                  # length(p) was replaced with as.numeric(names(p))

--- a/R/simStructure.R
+++ b/R/simStructure.R
@@ -132,6 +132,20 @@ simStructure <- function(dataS, method=c("direct", "multinom", "distribution"), 
                         )                         
     } else if ( method == "distribution" ) {
       hsizePH <- unlist(lapply(ls, function(l) spSample(NH[l], households[, l])))
+      hsizePH <- unlist(lapply(ls, function(l) {
+                 # spSample(NH[l], households[, l]) was removed and insides was adjusted
+                 # length(p) was replaced with as.numeric(names(p))
+        n <-  NH[l]
+        p <- households[, l] 
+                   
+        sample(as.numeric(names(p)),
+               size = n, 
+               replace = TRUE,
+               prob = p)
+    }                           
+                               )
+                        )
+     }                         
     }
     dataPH <- data.frame(hsize=as.factor(hsizePH), strata=factor(rep(ls, times=NH), levels=ls, ordered=is.ordered(strata)))
     households <- tableWt(dataPH)  # recompute number of households

--- a/R/simStructure.R
+++ b/R/simStructure.R
@@ -145,7 +145,6 @@ simStructure <- function(dataS, method=c("direct", "multinom", "distribution"), 
                                )
                         )
      }                         
-    }
     dataPH <- data.frame(hsize=as.factor(hsizePH), strata=factor(rep(ls, times=NH), levels=ls, ordered=is.ordered(strata)))
     households <- tableWt(dataPH)  # recompute number of households
   }

--- a/R/simStructure.R
+++ b/R/simStructure.R
@@ -118,6 +118,19 @@ simStructure <- function(dataS, method=c("direct", "multinom", "distribution"), 
       # boost <- 1/sqrt(fraction)
       # probs[probs < fraction] <- pmin(fraction, boost*probs[probs < fraction])
       hsizePH <- unlist(lapply(ls, function(l) spSample(NH[l], probs[l,])))
+      hsizePH <- unlist(lapply(ls, function(l) {
+                # spSample(NH[l], probs[l,]) was removed and insides was adjusted
+                # length(p) was replaced with as.numeric(names(p))
+        n <-  NH[l]
+        p <- probs[l,]
+        
+        sample(as.numeric(names(p)),
+               size = n, 
+               replace = TRUE,
+               prob = p)
+      }
+                               )
+                        )                         
     } else if ( method == "distribution" ) {
       hsizePH <- unlist(lapply(ls, function(l) spSample(NH[l], households[, l])))
     }
@@ -154,11 +167,7 @@ simStructure <- function(dataS, method=c("direct", "multinom", "distribution"), 
     n <- households[grid[i, 1], grid[i, 2]]
     w <- wH[split[[i]]]
     p <- w / sum(w)  # probability weights
-    if(length(p) == 0) {
-      integer(0)
-    } else {
-      spSample(n, p)
-    }
+    spSample(n, p)
   })
 
   ### generation of the household structure for the population

--- a/R/simStructure.R
+++ b/R/simStructure.R
@@ -117,7 +117,6 @@ simStructure <- function(dataS, method=c("direct", "multinom", "distribution"), 
       # fraction <- nrow(dataH)/nrow(dataPH)
       # boost <- 1/sqrt(fraction)
       # probs[probs < fraction] <- pmin(fraction, boost*probs[probs < fraction])
-      hsizePH <- unlist(lapply(ls, function(l) spSample(NH[l], probs[l,])))
       hsizePH <- unlist(lapply(ls, function(l) {
                 # spSample(NH[l], probs[l,]) was removed and insides was adjusted
                 # length(p) was replaced with as.numeric(names(p))

--- a/R/simStructure.R
+++ b/R/simStructure.R
@@ -43,7 +43,7 @@
 #' class(eusilcP)
 #' eusilcP
 #' 
-simStructure <- function(dataS, method=c("direct", "multinom", "distribution"), basicHHvars, seed=1) {
+simStructure <- function(dataS, method=c("direct", "multinom", "distribution"), basicHHvars, seed=1, MaxNWts = 10000000) {
   if ( !class(dataS) == "dataObj" ) {
     stop("Error. Please provide the input sample in the required format.\n
       It must be an object of class 'dataObj' that can be created using function specifyInput()!\n")
@@ -107,7 +107,7 @@ simStructure <- function(dataS, method=c("direct", "multinom", "distribution"), 
     if ( method == "multinom" ) {
       empty <- which(households == 0)
       # TODO: allow setting some more arguments
-      mod <- suppressWarnings(multinom(hsize~strata, weights=wH, data=dataH, trace=FALSE))
+      mod <- suppressWarnings(multinom(hsize~strata, weights=wH, data=dataH, trace=FALSE, MaxNWts = MaxNWts))
       newdata <- data.frame(strata=ls)
       rownames(newdata) <- ls
       probs <- as.matrix(predict(mod, newdata=newdata, type="probs"))
@@ -152,7 +152,11 @@ simStructure <- function(dataS, method=c("direct", "multinom", "distribution"), 
     n <- households[grid[i, 1], grid[i, 2]]
     w <- wH[split[[i]]]
     p <- w / sum(w)  # probability weights
-    spSample(n, p)
+    if(length(p) == 0) {
+      integer(0)
+    } else {
+      spSample(n, p)
+    }
   })
 
   ### generation of the household structure for the population


### PR DESCRIPTION
Hello,

I was playing with the method of multinom for simulation of household size
and had this error:
```
Error in nnet.default(X, Y, w, mask = mask, size = 0, skip = TRUE, softmax = TRUE, :
too many (1404) weights
```

So according to the answer in https://stackoverflow.com/questions/36303404/too-many-weights-in-multinomial-logistic-regression-and-the-code-is-running-for
I added argument MaxNWts which in the nnet package is in general for controlling the maximum number of weights.

Then another error appeared in lapply where we draw from original sample for each stratum
```
Error in sample.int(length(x), size, replace, prob) :
incorrect number of probabilities
```
This function 
```
  numbers <- lapply(1:ncomb, function(i) {
    n <- households[grid[i, 1], grid[i, 2]]
    w <- wH[split[[i]]]
    p <- w / sum(w)  # probability weights

    spSample(n, p)
  })
```
The reason for this error is that in my households size, there are these sizes 
```
> levels(as.factor(hsize))
 [1] "1"  "2"  "3"  "4"  "5"  "6"  "7"  "8"  "9"  "10" "11" "12" "13" "14" "15" "16" "19" "20"
```
You can see that I don't have size of 17 and 18.

Everything goes well until this function
```
hsizePH <- unlist(lapply(ls, function(l) spSample(NH[l], probs[l,])))
```
because it somehow changed the sizes of households
```
> levels(as.factor(hsizePH))
 [1] "1"  "2"  "3"  "4"  "5"  "6"  "7"  "8"  "9"  "10" "11" "12" "13" "14" "15" "16" "17" "18"
```
This happened because of spSample(NH[l],probs[l,])
which is function for sample(length(p),size=n, replace=TRUE,prob=p)
and here lies my problem p <- probs[l,]
```
> probs[l,]
           1            2            3            4            5            6            7 
0.2764668051 0.2697735219 0.1996712258 0.1852551015 0.0162689795 0.0489499869 0.0010677580 
           8            9           10           11           12           13           14 
0.0006122110 0.0002974661 0.0002422427 0.0002950224 0.0001680283 0.0001476288 0.0001612824 
          15           16           19           20 
0.0001576700 0.0001626591 0.0001522689 0.0001501416 
```
But the sample is done from household sizes from 1:18 because of the length(p), which is 18 but the maximum value in p is not.

So I solved it by replacing lenght(p) with as.numeric(names(p)). This secures that only household sizes that are truly in original dataset are then sampled.
```
> levels(as.factor(hsizePH))
 [1] "1"  "2"  "3"  "4"  "5"  "6"  "7"  "8"  "9"  "10" "11" "12" "13" "14" "15" "16" "19" "20"
```

After the code can run without errors.
What do you think about it?


