### PR TITLE
gh-actions: use ubuntu 20.04

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,12 +29,12 @@ jobs:
           - {os: windows-latest, r: '3.6'}
 
           # Use older ubuntu to maximise backward compatibility
-          - {os: ubuntu-18.04,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-18.04,   r: 'release'}
-          - {os: ubuntu-18.04,   r: 'oldrel-1'}
-          - {os: ubuntu-18.04,   r: 'oldrel-2'}
-          - {os: ubuntu-18.04,   r: 'oldrel-3'}
-          - {os: ubuntu-18.04,   r: 'oldrel-4'}
+          - {os: ubuntu-20.04,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-20.04,   r: 'release'}
+          - {os: ubuntu-20.04,   r: 'oldrel-1'}
+          - {os: ubuntu-20.04,   r: 'oldrel-2'}
+          - {os: ubuntu-20.04,   r: 'oldrel-3'}
+          - {os: ubuntu-20.04,   r: 'oldrel-4'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
ubuntu 18.04 is no longer supported on gh-actions since 2023-04-01. this pr changes the gh-actions config to use ubuntu 20.04 instead.