### PR TITLE
Update simStructure.R

### DIFF
--- a/R/simStructure.R
+++ b/R/simStructure.R
@@ -94,6 +94,11 @@ simStructure <- function(dataS, method=c("direct", "multinom", "distribution"), 
     strata <- factor(rep(1, nrow(dataS@data)))
   }
 
+  # Check levels for multinom method
+  if ( method == "multinom" & length(levels(strata)) < 2 ) {
+    stop("Your strata region must have 2 or more levels!\n")
+  }
+
   ##### set up household structure
 
   # generate variables on household level (indicated by H)


### PR DESCRIPTION
Hello,

I have a little improvement proposal.

In function simStructure if you run multinom method on the region with only one region as strata, you will get an error. For example, in the Czech Republic, we have the capital Prague, which is its own region (NUTS 3) and its own district (LAU 1) and so on. Division starts only in city districts.

So because of our capital, I always get this error. This is caused by the insides of the nnet package that you use for the fit of the multinom model.
>       mod <- suppressWarnings(multinom(hsize~strata, weights=wH, data=dataH, trace=FALSE, MaxNWts = MaxNWts))
>  Error in `contrasts<-`(`*tmp*`, value = contr.funs[1 + isOF[nn]]) : 
  contrasts can be applied only to factors with 2 or more levels

This may be a niche problem, but because I simulate one region at a time with strata at districts (LAU 1), then I can not try multinom for Prague.

I do not mind, but at least I can add a better warning for another user that he has this problem in his data.

>     #  Check levels for multinom method
>     if ( method == "multinom" & length(levels(strata)) < 2 ) {
>     stop("Your strata region must have 2 or more levels!\n")
>     }


Do you agree?