### PR TITLE
 address issue 22 by @Kyoshido 

### DIFF
--- a/R/simCategorical.R
+++ b/R/simCategorical.R
@@ -64,6 +64,7 @@ generateValues <- function(dataSample, dataPop, params) {
       probs <- predict(mod, newdata=newdata, type="probs")
     }else if ( meth %in% c("ctree","cforest") ) {
       probs <- predict(mod, newdata=data.table(newdata), type="prob")
+      probs <- split(probs, seq(nrow(probs)))  
       probs <- do.call("rbind",probs)
 	    if(ncol(probs)==2){
         probs <- probs[,2]


### PR DESCRIPTION
Hello, 

I described my problem in issue https://github.com/statistikat/simPop/issues/22

When I was at Statistic Austria I think that we repaired only package party to partykit, but we forgot to repair this issue.

 I got this error

> Error in do.call("rbind", probs) : second argument must be a list

So this is in simCategorical() specifically in row 67 probs <- predict(mod, newdata=data.table(newdata), type="prob") 

And the reason for this error is that party package output is list and partykit package output is dataframe.

This makes it works :) 
> probs <- split(probs, seq(nrow(probs)))