### PR TITLE
Update specifyInput.R

### DIFF
--- a/R/specifyInput.R
+++ b/R/specifyInput.R
@@ -60,8 +60,8 @@ specifyInput <- function(data, hhid, hhsize=NULL, pid=NULL, weight=NULL,
     }
   }else{
     # initialize dummy strata used by other methods in package
-    strata <- paste(c("DUMMY_STRATA_",sample(c(letters,LETTERS),8,replace=TRUE)), collapse="")
-    df[[strata]] <- factor(1)
+    strata_col <- paste(c("DUMMY_STRATA_",sample(c(letters,LETTERS),8,replace=TRUE)), collapse="")
+    data[[strata_col]] <- factor(1)
   }
 
   data <- as.data.table(data)


### PR DESCRIPTION
Avoiding: "Error in df[[strata]] <- factor(1) : 
  object of type 'closure' is not subsettable" in the case where the strata variable is null. `df` should 'data', I think. And rename `strata` column name to avoid a name clash.

Many thanks for your work on this. I learned about simPop at the IMA conference this week.