### PR TITLE
object of type 'closure' is not subsettable work around

### DIFF
--- a/R/specifyInput.R
+++ b/R/specifyInput.R
@@ -60,8 +60,8 @@ specifyInput <- function(data, hhid, hhsize=NULL, pid=NULL, weight=NULL,
     }
   }else{
     # initialize dummy strata used by other methods in package
-    strata <- paste(c("DUMMY_STRATA_",sample(c(letters,LETTERS),8,replace=TRUE)), collapse="")
-    df[[strata]] <- factor(1)
+    strata_col <- paste(c("DUMMY_STRATA_",sample(c(letters,LETTERS),8,replace=TRUE)), collapse="")
+    data[[strata_col]] <- factor(1)
   }
 
   data <- as.data.table(data)

--- a/R/specifyInput.R
+++ b/R/specifyInput.R
@@ -60,8 +60,8 @@ specifyInput <- function(data, hhid, hhsize=NULL, pid=NULL, weight=NULL,
     }
   }else{
     # initialize dummy strata used by other methods in package
-    strata_col <- paste(c("DUMMY_STRATA_",sample(c(letters,LETTERS),8,replace=TRUE)), collapse="")
-    data[[strata_col]] <- factor(1)
+    strata <- paste(c("DUMMY_STRATA_",sample(c(letters,LETTERS),8,replace=TRUE)), collapse="")
+    data[[strata]] <- factor(1)
   }
 
   data <- as.data.table(data)


### PR DESCRIPTION
Hi,

I think `df` should be `data` here to avoid "object of type 'closure' is not subsettable". 

Many thanks for your work on this - heard about it at the IMA conference this week.