### PR TITLE
Update calibSample method argument check

### DIFF
--- a/R/calibSample.R
+++ b/R/calibSample.R
@@ -121,6 +121,10 @@ setMethod("calibSample", c(inp="df_or_dataObj_or_simPopObj", totals="dataFrame_o
   args <- list(...)
   if ( is.null(args$method) ) {
     method <- "raking"
+  } else if (args$method %in% c("raking", "linear", "logit")) {
+    method <- args$method
+  } else {
+    stop("calibSample 'method' option should be one of c('raking', 'linear', 'logit') \n")
   }
   if ( is.null(args$bounds) ) {
     bounds <- c(0,10)


### PR DESCRIPTION
method sent to calibSample_work is not currently set with user specified option from calibSample function 
and errors out due to non set method at calibSample_work