### PR TITLE
specifyInput add check for missing

### DIFF
--- a/R/specifyInput.R
+++ b/R/specifyInput.R
@@ -39,6 +39,10 @@
 specifyInput <- function(data, hhid=NULL, hhsize=NULL, pid=NULL, weight=NULL,
                          strata=NULL, population=FALSE) {
   
+  if (missing(hhid)) hhid <- NULL
+  if (missing(hhsize)) hhsize <- NULL
+  if (missing(pid)) pid <- NULL
+  
   hhid.simPop <- weight.simPop <- NULL
   
   if(!(inherits(data,"data.frame") | inherits(data,"data.table"))){


### PR DESCRIPTION
Hello,

so I was tasked with creating synthetic data for a dataset with out `hhid` and `hhsize`.  And I stumbled upon two errors  related to hhid. 

Let's use example with `eusilc` data.
------------------------------------------------------------------------

The code below is working properly.

```{r eval=FALSE}
library("simPop")
data("eusilcS")
seed <- 1234
```

```{r eval=FALSE}
inp <- specifyInput(data=eusilcS,
                    hhid="db030",
                    hhsize="hsize",
                    strata="db040",
                    weight="db090"
                    )
inp
```

```         
 -------------- 
survey sample of size 11725 x 19 

 Selected important variables: 

 household ID: db030
 personal ID: pid
 variable household size: hsize
 sampling weight: db090
 strata: db040
 -------------- 
```

# 1. Now let’s take a look at a similar code. But `hhid` and `hhsize` are absent.

```{r eval=FALSE}
inp <- specifyInput(data=eusilcS,
                    strata="db040",
                    weight="db090"
                    )
inp
```

```         
Error in specifyInput(data = eusilcS, strata = "db040", weight = "db090") :    argument "hhid" is missing, with no default
```

Ok, so there is an error argument `"hhid" is missing, with no default`

The function definition of `specifyInput` says:

```         
specifyInput <- function(data, hhid=NULL, hhsize=NULL, pid=NULL, weight=NULL, strata=NULL, population=FALSE)
```

This suggests that `hhid` is optional, because it has a default value `NULL`.

Inside the function, there's this block:

```         
if(is.null(hhid)){
  # initialize hhid
  hhid <- "hhid.simPop"
  data[, hhid.simPop := .I]
}
```

So why do we get this error `"hhid" is missing, with no default` then?

Problem here is not `hhid = NULL`, but that `hhid` is missing altogether. Which is exactly what the error message explicitly says.

When a parameter is not passed at all, inside the function, `hhid` is not yet evaluated — it is not `NULL` — it is missing.

So inside the function, the condition `is.null(hhid)` is evaluted with error argument `"hhid" is missing, with no default`, because `hhid` is missing — not provided yet at all.

On an object that is not defined → hence the error.

So I recommend adding these checks at the beginning of the function:

```         
if (missing(hhid)) hhid <- NULL
if (missing(hhsize)) hhsize <- NULL
if (missing(pid)) pid <- NULL
```

This way, the function will work as expected and will not display an error message when `hhid` or `hhsize` are not provided.

So I added it to my fork:

```{r eval=FALSE}
devtools::install_github("kyoshido/simPop")
library(simPop)
inp <- specifyInput(data=eusilcS,
                    strata="db040",
                    weight="db090"
                    )
inp
```

```         
 -------------- 
survey sample of size 11725 x 21 

 Selected important variables: 

 household ID: hhid.simPop
 personal ID: pid.simPop
 variable household size: hhsize.simPop
 sampling weight: db090
 strata: db040
 -------------- 
```

**Now it works as expected.**

## 2.  **However, there was another error when the parameters were included, but set to `NULL`.**

```{r eval=FALSE}
inp <- specifyInput(data=eusilcS,
                    hhid=NULL,
                    hhsize=NULL,
                    strata="db040",
                    weight="db090"
                    )
inp
```

```         
Error in if (!inherits(hhid, "character") | length(hhid) != 1 | is.na(match(hhid,  : 
  argument is of length zero
```
 the error  message says `argument is of length zero`.

When we explicitly write `hhid = NULL`
The function see:
```
hhid  # is NULL
inherits(hhid, "character")  # FALSE
length(hhid)  # 0
match(hhid, colnames(data))  # integer(0)
is.na(match(hhid, colnames(data)))  # logical(0)
```

Logical test is not properly evaluated → hence the error.

But all this was properly handled by adding the check for `missing(hhid)` at the beginning of the function.













































































